### PR TITLE
Adds chart for zserver service

### DIFF
--- a/charts/mod-z3950/templates/zservice.yaml
+++ b/charts/mod-z3950/templates/zservice.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mod-z3950.fullname" . }}
+  labels:
+    {{- include "mod-z3950.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.zserver.type }}
+  ports:
+    - port: {{ .Values.zserver.port }}
+      targetPort: {{ .Values.zserver.containerPort }}
+      protocol: TCP
+      name: z3950
+    - port: {{ .Values.sru.port }}
+      targetPort: {{ .Values.zserver.containerPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mod-z3950.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Mod-z3950 will need a special service template for the zserver and sru services. This will be a file that is not synched with the upstream repo.